### PR TITLE
Handling IAM group membership

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -1,11 +1,14 @@
 from flask import render_template, request
 from app import app
 
+@app.errorhandler(403)
+def forbidden(error):
+    return render_template('403.html', message=error.description)
+
 @app.errorhandler(404)
 def page_not_found(error):
 	app.logger.error('Page not found: %s', (request.path))
 	return render_template('404.html'), 404
-
 
 @app.errorhandler(500)
 def internal_server_error(error):

--- a/app/settings.py
+++ b/app/settings.py
@@ -16,3 +16,5 @@ orchestratorConf = {
 }
 
 external_links = app.config.get('EXTERNAL_LINKS') if app.config.get('EXTERNAL_LINKS') else []
+
+iamGroups = app.config.get('IAM_GROUP_MEMBERSHIP')


### PR DESCRIPTION
Added check on IAM group membership:
if a list of groups is configured in IAM_GROUP_MEMBERSHIP, the user groups are checked and a 403 error is raised, then the user is redirected to an error page inviting to apply for the requested membership.